### PR TITLE
fixed extracting numeric IDs from filenames

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -383,7 +383,9 @@ edf.batch <- function(EDFfiles=NULL,pattern=NULL,samples=FALSE,do.plot=TRUE,save
     # print(paste('Loading file:',path.expand(EDFfiles[[f]])))
     # get a clean name from the edf files
     justfile <- sub("^([^.]*).*", "\\1", basename(EDFfiles[[f]]))
-    ID <- as.numeric(gsub("([0-9]*).*","\\1",justfile))
+    # replace every occurrence of not-digits with nothing
+    # this gives then a string that contains only numbers
+    ID <- as.numeric(gsub("([^0-9])","",justfile))
 
     #import
     trials <- edf.trials(EDFfiles[[f]],samples=samples,eventmask=T)


### PR DESCRIPTION
I tried to use your itrackR package but it only gave me NaNs in the ID columns. Finally, I tracked down the bug to edfR here and now it works for me.
BTW, Is there a reason why the ID should be only numeric? I tend to use string for subjects IDs like `subject3`, because otherwise R misinterprets the subjects and gives a meaning to the subject numbers (depending on the analysis). So, if there is no reason, personally I would prefer to use the whole filename for the ID column (without extension, i.e., `justfile`) and not only the numbers.
